### PR TITLE
Fix iPad display cutoff and input rotation on iOS 18

### DIFF
--- a/src/STHIDEventGenerator.mm
+++ b/src/STHIDEventGenerator.mm
@@ -160,16 +160,7 @@ NS_INLINE void _DTXCalcLinearPinchStartEndPoints(CGRect bounds, CGFloat pixelsSc
         return nil;
 
     CGSize screenSize = [[UIScreen mainScreen] _unjailedReferenceBoundsInPixels].size;
-#if !TARGET_IPHONE_SIMULATOR
-    BOOL isPad = ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
-    if (isPad) {
-        _physicalScreenSize = CGSizeMake(screenSize.height, screenSize.width);
-    } else {
-#endif
-        _physicalScreenSize = CGSizeMake(screenSize.width, screenSize.height);
-#if !TARGET_IPHONE_SIMULATOR
-    }
-#endif
+    _physicalScreenSize = screenSize;
 
     dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
                                                                          QOS_CLASS_USER_INTERACTIVE, 0);

--- a/src/ScreenCapturer.mm
+++ b/src/ScreenCapturer.mm
@@ -76,19 +76,8 @@ void CARenderServerRenderDisplay(kern_return_t a, CFStringRef b, IOSurfaceRef su
 
     int width, height;
     CGSize screenSize = [[UIScreen mainScreen] _unjailedReferenceBoundsInPixels].size;
-
-#if !TARGET_IPHONE_SIMULATOR
-    BOOL isPad = ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
-    if (isPad) {
-        width = (int)round(screenSize.height);
-        height = (int)round(screenSize.width);
-    } else {
-#endif
-        width = (int)round(screenSize.width);
-        height = (int)round(screenSize.height);
-#if !TARGET_IPHONE_SIMULATOR
-    }
-#endif
+    width = (int)round(screenSize.width);
+    height = (int)round(screenSize.height);
 
     // Pixel format for Alpha, Red, Green and Blue
     unsigned pixelFormat = 0x42475241; // 'ARGB'

--- a/src/trollvncserver.mm
+++ b/src/trollvncserver.mm
@@ -2988,18 +2988,7 @@ NS_INLINE CGPoint vncPointToDevicePoint(int vx, int vy) {
     // back to device capture space (portrait, gSrcWidth x gSrcHeight), inverting rotation.
     int rotQ = (gOrientationSyncEnabled ? gRotationQuad.load(std::memory_order_relaxed) : 0) & 3;
 
-#if !TARGET_IPHONE_SIMULATOR
-    // On iPad, align input coordinates with an extra +270° CW rotation
-    // (i.e., -90°) per corrected requirement.
-    static BOOL sIsPad = NO;
-    static dispatch_once_t sPadOnce;
-    dispatch_once(&sPadOnce, ^{
-        sIsPad = ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
-    });
-    int effRotQ = (rotQ + (sIsPad ? 3 : 0)) & 3;
-#else
     int effRotQ = rotQ;
-#endif
 
     // Dimensions of the rotated (pre-scale) stage
     int rotW = (effRotQ % 2 == 0) ? gSrcWidth : gSrcHeight;

--- a/src/trollvncserver.mm
+++ b/src/trollvncserver.mm
@@ -4408,16 +4408,6 @@ NS_INLINE UIInterfaceOrientation makeInterfaceOrientationRotate90(UIInterfaceOri
 
 // Map UIInterfaceOrientation to rotation quadrant (clockwise degrees/90)
 NS_INLINE int rotationForOrientation(UIInterfaceOrientation o) {
-#if !TARGET_IPHONE_SIMULATOR
-    static BOOL sIsPad;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sIsPad = ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
-    });
-    if (sIsPad) {
-        o = makeInterfaceOrientationRotate90(o);
-    }
-#endif
     switch (o) {
     case UIInterfaceOrientationPortrait:
     default:


### PR DESCRIPTION
## Summary

- Fixes display cutoff issue on iPad 7 (iOS 18) where only ~75% of the screen was visible
- Fixes input rotation being 90° off after the display fix (swipe up acted as swipe right)
- Removes iPad-specific dimension swap and rotation offset workarounds that are no longer needed on iOS 18

## Changes

Removed 4 iPad-specific compensations that assumed landscape-first dimension reporting:

1. **ScreenCapturer.mm**: Removed width/height swap for iPad
2. **STHIDEventGenerator.mm**: Removed physical screen size swap for iPad
3. **trollvncserver.mm**: Removed +90° orientation offset in `rotationForOrientation()`
4. **trollvncserver.mm**: Removed +270° input rotation offset in `vncPointToDevicePoint()`

## Root Cause

iOS 18 on iPad 7 reports screen dimensions in standard portrait-first order (1620x2160), but the original code assumed iPads reported landscape-first. The workarounds were swapping dimensions and adding rotation offsets to compensate, which caused:
- Display cutoff (wrong framebuffer size)
- Input rotation mismatch (orphaned +270° offset after partial fix)

## Test Plan

- [x] Tested on iPad 7 (iPadOS 18.2.1) - full display visible, no cutoff
- [x] Tested on iPhone X (iOS 16.7.12) - no regression, works correctly
- [x] Swipe gestures work correctly (up=up, left=left, etc.)
- [x] Landscape rotation works - dimensions swap to 2160x1620
- [x] Touch/cursor input accurate in all orientations

🤖 Generated with [Claude Code](https://claude.ai/claude-code)